### PR TITLE
Issue 2156

### DIFF
--- a/browser/main/Detail/index.js
+++ b/browser/main/Detail/index.js
@@ -39,42 +39,29 @@ class Detail extends React.Component {
     const { location, data, params, config } = this.props
     let note = null
 
-    function differenceWithTrashed (notes) {
-      const trashedNotes = data.trashedSet.toJS().map(uniqueKey => data.noteMap.get(uniqueKey))
-      return _.differenceWith(notes, trashedNotes, (note, trashed) => note.key === trashed.key)
-    }
-
     if (location.query.key != null) {
       const noteKey = location.query.key
-      let displayedNotes = []
-
-      if (location.pathname.match(/\/home/) || location.pathname.match(/alltags/)) {
-        const allNotes = data.noteMap.map(note => note)
-        displayedNotes = differenceWithTrashed(allNotes)
-      }
-
-      if (location.pathname.match(/\/starred/)) {
-        displayedNotes = data.starredSet.toJS().map(uniqueKey => data.noteMap.get(uniqueKey))
-      }
+      const allNotes = data.noteMap.map(note => note)
+      const trashedNotes = data.trashedSet.toJS().map(uniqueKey => data.noteMap.get(uniqueKey))
+      let displayedNotes = allNotes
 
       if (location.pathname.match(/\/searched/)) {
         const searchStr = params.searchword
-        const allNotes = data.noteMap.map(note => note)
-        const searchedNotes = searchStr === undefined || searchStr === '' ? allNotes
+        displayedNotes = searchStr === undefined || searchStr === '' ? allNotes
           : searchFromNotes(allNotes, searchStr)
-        displayedNotes = differenceWithTrashed(searchedNotes)
-      }
-
-      if (location.pathname.match(/\/trashed/)) {
-        displayedNotes = data.trashedSet.toJS().map(uniqueKey => data.noteMap.get(uniqueKey))
       }
 
       if (location.pathname.match(/\/tags/)) {
         const listOfTags = params.tagname.split(' ')
-        const searchedNotes = data.noteMap.map(note => note).filter(note =>
+        displayedNotes = data.noteMap.map(note => note).filter(note =>
           listOfTags.every(tag => note.tags.includes(tag))
         )
-        displayedNotes = differenceWithTrashed(searchedNotes)
+      }
+
+      if (location.pathname.match(/\/trashed/)) {
+        displayedNotes = trashedNotes
+      } else {
+        displayedNotes = _.differenceWith(displayedNotes, trashedNotes, (note, trashed) => note.key === trashed.key)
       }
 
       const noteKeys = displayedNotes.map(note => note.key)

--- a/browser/main/Detail/index.js
+++ b/browser/main/Detail/index.js
@@ -38,30 +38,43 @@ class Detail extends React.Component {
   render () {
     const { location, data, params, config } = this.props
     let note = null
+
+    function differenceWithTrashed (notes) {
+      const trashedNotes = data.trashedSet.toJS().map(uniqueKey => data.noteMap.get(uniqueKey))
+      return _.differenceWith(notes, trashedNotes, (note, trashed) => note.key === trashed.key)
+    }
+
     if (location.query.key != null) {
       const noteKey = location.query.key
       let displayedNotes = []
 
       if (location.pathname.match(/\/home/) || location.pathname.match(/alltags/)) {
-        displayedNotes = data.noteMap.map(note => note)
+        const allNotes = data.noteMap.map(note => note)
+        displayedNotes = differenceWithTrashed(allNotes)
       }
+
       if (location.pathname.match(/\/starred/)) {
         displayedNotes = data.starredSet.toJS().map(uniqueKey => data.noteMap.get(uniqueKey))
       }
+
       if (location.pathname.match(/\/searched/)) {
         const searchStr = params.searchword
         const allNotes = data.noteMap.map(note => note)
-        displayedNotes = searchStr === undefined || searchStr === '' ? allNotes
+        const searchedNotes = searchStr === undefined || searchStr === '' ? allNotes
           : searchFromNotes(allNotes, searchStr)
+        displayedNotes = differenceWithTrashed(searchedNotes)
       }
+
       if (location.pathname.match(/\/trashed/)) {
         displayedNotes = data.trashedSet.toJS().map(uniqueKey => data.noteMap.get(uniqueKey))
       }
+
       if (location.pathname.match(/\/tags/)) {
         const listOfTags = params.tagname.split(' ')
-        displayedNotes = data.noteMap.map(note => note).filter(note =>
+        const searchedNotes = data.noteMap.map(note => note).filter(note =>
           listOfTags.every(tag => note.tags.includes(tag))
         )
+        displayedNotes = differenceWithTrashed(searchedNotes)
       }
 
       const noteKeys = displayedNotes.map(note => note.key)

--- a/browser/main/Detail/index.js
+++ b/browser/main/Detail/index.js
@@ -9,6 +9,7 @@ import ee from 'browser/main/lib/eventEmitter'
 import StatusBar from '../StatusBar'
 import i18n from 'browser/lib/i18n'
 import debounceRender from 'react-debounce-render'
+import searchFromNotes from 'browser/lib/search'
 
 const OSX = global.process.platform === 'darwin'
 
@@ -35,11 +36,38 @@ class Detail extends React.Component {
   }
 
   render () {
-    const { location, data, config } = this.props
+    const { location, data, params, config } = this.props
     let note = null
     if (location.query.key != null) {
       const noteKey = location.query.key
-      note = data.noteMap.get(noteKey)
+      let displayedNotes, noteKeys
+
+      if (location.pathname.match(/\/home/) || location.pathname.match(/alltags/)) {
+        displayedNotes = data.noteMap.map(note => note)
+      }
+      if (location.pathname.match(/\/starred/)) {
+        displayedNotes = data.starredSet.toJS().map(uniqueKey => data.noteMap.get(uniqueKey))
+      }
+      if (location.pathname.match(/\/searched/)) {
+        displayedNotes = searchFromNotes(
+          data.noteMap.map(note => note),
+          params.searchword
+        )
+      }
+      if (location.pathname.match(/\/trashed/)) {
+        displayedNotes = data.trashedSet.toJS().map(uniqueKey => data.noteMap.get(uniqueKey))
+      }
+      if (location.pathname.match(/\/tags/)) {
+        const listOfTags = params.tagname.split(' ')
+        displayedNotes = data.noteMap.map(note => note).filter(note =>
+          listOfTags.every(tag => note.tags.includes(tag))
+        )
+      }
+
+      noteKeys = displayedNotes.map(note => note.key)
+      if (noteKeys.includes(noteKey)) {
+        note = data.noteMap.get(noteKey)
+      }
     }
 
     if (note == null) {

--- a/browser/main/Detail/index.js
+++ b/browser/main/Detail/index.js
@@ -40,7 +40,7 @@ class Detail extends React.Component {
     let note = null
     if (location.query.key != null) {
       const noteKey = location.query.key
-      let displayedNotes, noteKeys
+      let displayedNotes = []
 
       if (location.pathname.match(/\/home/) || location.pathname.match(/alltags/)) {
         displayedNotes = data.noteMap.map(note => note)
@@ -49,10 +49,10 @@ class Detail extends React.Component {
         displayedNotes = data.starredSet.toJS().map(uniqueKey => data.noteMap.get(uniqueKey))
       }
       if (location.pathname.match(/\/searched/)) {
-        displayedNotes = searchFromNotes(
-          data.noteMap.map(note => note),
-          params.searchword
-        )
+        const searchStr = params.searchword
+        const allNotes = data.noteMap.map(note => note)
+        displayedNotes = searchStr === undefined || searchStr === '' ? allNotes
+          : searchFromNotes(allNotes, searchStr)
       }
       if (location.pathname.match(/\/trashed/)) {
         displayedNotes = data.trashedSet.toJS().map(uniqueKey => data.noteMap.get(uniqueKey))
@@ -64,7 +64,7 @@ class Detail extends React.Component {
         )
       }
 
-      noteKeys = displayedNotes.map(note => note.key)
+      const noteKeys = displayedNotes.map(note => note.key)
       if (noteKeys.includes(noteKey)) {
         note = data.noteMap.get(noteKey)
       }


### PR DESCRIPTION
Solved [issue #2156](https://github.com/BoostIO/Boostnote/issues/2156)
This bug appeared due to the fact that in 'Detail' component the current note was searched in a chunk of Redux store in which all of a user's notes are stored. Not defined by the selected tab. Both trashed and not. This problem was solved by different searching the current note for each particular case: homepage, trashed and starred items, input and tag searching. In this way, a removed or restored note is checked for being trashed now.